### PR TITLE
feat(blog): Narração — listen to posts in the author's cloned voice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Type-safe markdown content with Zod schemas defined in `src/content/config.ts`:
 - **blog/** - Blog posts: title, pubDatetime, modDatetime?, description, tags, language (pt/en, default en), draft, featured, ogImage (enforced ≥ 1200×630)
 - **estudo/** - Study materials: title, category, tags (default `["direito"]`), language (default pt), draft
 - **code/** - Code-focused notes: same shape as `estudo` with default tag `["code"]`
-- **vela/** - Sailing notes (the Vela theme; see CONTEXT.md): same shape as `estudo` with default tag `["vela"]`, served at `/vela`
+- **vela/** - Sailing notes (the Vela theme; see CONTEXT.md): same shape as `estudo` with default tag `["vela"]`, served at `/vela`. The `/vela` section also hosts two **regatta boards** that are NOT markdown — see "Vela regatta boards" below.
 
 The registered collections are `{ blog, estudo, code, vela }` in `src/content/config.ts`. Note the directory is **blog/** but its public route is `/posts` (the listing layouts read the `blog` collection).
 
@@ -50,6 +50,7 @@ When adding a new collection, update `src/content/config.ts`, add a matching rou
 - **src/constants/** - Static data tables that drive UI without a content collection:
   - `links.ts` — bookmarks shown on the `/link` page (typed by `LinkItem`/`LinkCategory` in `src/types.ts`).
   - `labMenu.ts` — entries for the Lab dropdown in `Header.astro` (see CONTEXT.md for the Lab link vs. Lab group distinction; groups are one level deep only). Edit this file to add/reorder Lab menu items rather than touching the header markup.
+  - `calendario2026.ts` / `resultados2026.ts` — typed source-of-truth data for the Vela regatta boards (see "Vela regatta boards" below). These define their own exported types inline (not in `src/types.ts`).
 - **src/workers/** - Vite ES-module workers (format set to `"es"` in `astro.config.ts`). `pdf-processor.worker.ts` offloads PDF parsing from the main thread for the `/pdf` page.
 - **src/scripts/** - Client-side scripts (e.g. `tempo-chart.ts` drives the `/tempo` visualization)
 - **src/helpers/** - Static JSON data: `themes.json`, `languagesList.json`, `podcastMainCategories.json`. No path alias exists for this directory; import with a relative path or use `public/` if needed client-side.
@@ -61,6 +62,16 @@ When adding a new collection, update `src/content/config.ts`, add a matching rou
 - **`/pdf`** - Client-side PDF → PNG converter. Uses `pdfjs-dist` to render pages and `@zip.js/zip.js` to bundle output; `pdf-processor.worker.ts` handles work off the main thread. Nothing is uploaded to a server.
 - **`/tempo`** - Visualization page rendered by `TempoChart.astro` using data from `src/scripts/tempo-chart.ts`.
 - **`/gpg`** - Static page exposing the author's GPG public key for secure contact (single `index.astro`).
+
+### Vela regatta boards
+The `/vela` section serves two data-driven boards alongside the markdown `vela` collection:
+- **`/vela/calendario`** (`calendario.astro`) — Portuguese cruising-regatta calendar, driven by `src/constants/calendario2026.ts`. Uses **ISO dates** because the board sorts/filters by date and recomputes the cross-region "Próximas provas" view.
+- **`/vela/resultados`** (`resultados.astro`) — regatta standings, driven by `src/constants/resultados2026.ts`. Orders by **region** and never sorts by date, so `date` is kept as the free-text display string exactly as published (do not "fix" these to ISO).
+
+These boards deliberately keep their data as typed constants in `src/constants/` rather than a content collection. The rationale is recorded in `docs/adr/0001-calendario-source-of-truth.md` — read it before migrating this data or proposing a collection. The file header comments also list the authoritative per-region source URLs; preserve them when editing.
+
+### Architecture Decision Records
+`docs/adr/` holds ADRs documenting non-obvious decisions (currently `0001-calendario-source-of-truth.md`). Consult the relevant ADR before reversing a decision it covers, and add a new ADR when making a similarly load-bearing choice.
 
 ### Path Aliases
 Declared in both `tsconfig.json` (for the type checker) and `astro.config.ts` under `vite.resolve.alias` (for the bundler) — keep them in sync when adding a new alias: `@components/*`, `@utils/*`, `@layouts/*`, `@content/*`, `@config`, `@assets/*`, `@styles/*`, `@/types`, `@contexts/*`, `@constants/*`, `@pages/*`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,24 @@ A single sailing race/event in the Calendario. Each Regata is one entry regardle
 ### Resultados
 The race-results board at `/vela/resultados`, listed in the Vela dropdown. Shows the season's *finished* events with their podium standings per class (filter by region/class, free-text boat search). Its source of truth is a typed constants file (`src/constants/resultados2026.ts`), mirroring Calendario. Independent of the Calendario board: it has its own data and does **not** share a key with `Regata`, even though the same race may appear in both boards (worded slightly differently). An event here lists podium **rows** (boat, skipper, club) grouped by **class**; an event with no published standings is marked **pending**.
 
+## Audio
+
+### Narração
+The spoken-word version of a blog **Post**: an MP3 synthesized from the post's text in Alexandre's cloned voice, played from the **Ouvir control** on the post's date line. Pre-generated when the post is published/edited and served as a static file; not produced at read time. _Avoid_: podcast, audiobook, gravação.
+
+### Voz clonada
+Alexandre's voice reproduced by a third-party TTS provider's voice-cloning model — the single voice that reads every **Narração**, in both pt and en. The provider is accessed behind a swappable adapter, so "Voz clonada" names the voice, not any one vendor. _Avoid_: gravação (implies a hand-recorded human take, which this is not).
+
+### Ouvir control
+The compact play/pause button shown inline on a blog post's date line that plays the post's **Narração**. Present only when a Narração exists for that post.
+
+## Relationships
+
+- A blog **Post** has at most one **Narração**; the `estudo`, `code`, and `vela` collections have none (no date line, no Narração).
+- Every **Narração** is produced by the same **Voz clonada**.
+- The **Ouvir control** plays exactly one **Narração** — the one for the Post it sits on.
+
 ## Flagged ambiguities
 
+- "biblioteca de voz" / "gravei a minha voz" was first read as hand-recorded audio files, one per article. Resolved: it means a **Voz clonada** (voice samples → a TTS model that reads any text); there is no per-article human recording. The synthesized output is a **Narração**.
 - "Vela" previously referred only to the `LinkCategory` on `/link`. It now also names a top-level dropdown. Resolved: same theme, two surfaces, disjoint URLs (mirrors the Lab vs. `/link` rule).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,46 +5,58 @@ Glossary for Xani. Defines terms whose meaning isn't obvious from the code alone
 ## Navigation
 
 ### Lab dropdown
+
 The dropdown menu in the top nav labeled "Lab". Lives in `src/components/Header.astro`. Its items are nav targets to standalone lab pages (e.g. `/tempo`, `/pdf`) and external mini-apps. Distinct from — and unrelated to — the `/link` page.
 
 ### Lab menu item
+
 An entry in the Lab dropdown. Two kinds:
+
 - **Lab link** — terminal item; clicking navigates somewhere (internal route or external URL).
 - **Lab group** — parent item that holds children, forming a one-level submenu. Groups exist to organise related Lab links as the dropdown grows; a group cannot itself contain another group.
 
 ### `/link` page bookmarks
+
 Curated bookmarks shown on the `/link` page. Each is a `LinkItem` (see `src/types.ts`) belonging to a `LinkCategory`. These are unrelated to the Lab dropdown: a URL appearing in the Lab dropdown does **not** appear on `/link`, and vice versa.
 
 ## Themes
 
-A **theme** is a single domain concept that surfaces in more than one place in the nav. The same theme name applies to *both* surfaces; the URLs across those surfaces stay disjoint (no URL appears on more than one surface).
+A **theme** is a single domain concept that surfaces in more than one place in the nav. The same theme name applies to _both_ surfaces; the URLs across those surfaces stay disjoint (no URL appears on more than one surface).
 
 ### Vela
+
 The sailing/sea theme. Surfaces in three places, with disjoint URLs:
+
 - **`/link` page**, under `LinkCategory.VELA` — third-party reference sites (federations, regattas, charts).
 - **Vela dropdown** in the top nav — Alexandre's own sailing surfaces: external mini-apps (e.g. `mare`) and internal tools (the **Calendario** board at `/vela/calendario` and the **Resultados** board at `/vela/resultados`).
-- **`/vela` content collection** — Alexandre's own sailing *notes* (prose). Reached via the **Lesson** dropdown, not the Vela dropdown.
+- **`/vela` content collection** — Alexandre's own sailing _notes_ (prose). Reached via the **Lesson** dropdown, not the Vela dropdown.
 
 A URL belongs to at most one of these surfaces. Third-party sailing sites go under `/link`; Alexandre's own apps/tools go in the Vela dropdown; his written notes are the `/vela` collection.
 
 ### Calendario
+
 The interactive sailing-race board at `/vela/calendario`, listed in the Vela dropdown. Shows the year's regattas (filter by region/class/status, free-text search). Its source of truth is a typed constants file, **not** the `/vela` content collection — see ADR.
 
 ### Regata
+
 A single sailing race/event in the Calendario. Each Regata is one entry regardless of how many regional tables it appeared in originally (the source markdown listed some races more than once; the board holds each once).
 
 ### Resultados
-The race-results board at `/vela/resultados`, listed in the Vela dropdown. Shows the season's *finished* events with their podium standings per class (filter by region/class, free-text boat search). Its source of truth is a typed constants file (`src/constants/resultados2026.ts`), mirroring Calendario. Independent of the Calendario board: it has its own data and does **not** share a key with `Regata`, even though the same race may appear in both boards (worded slightly differently). An event here lists podium **rows** (boat, skipper, club) grouped by **class**; an event with no published standings is marked **pending**.
+
+The race-results board at `/vela/resultados`, listed in the Vela dropdown. Shows the season's _finished_ events with their podium standings per class (filter by region/class, free-text boat search). Its source of truth is a typed constants file (`src/constants/resultados2026.ts`), mirroring Calendario. Independent of the Calendario board: it has its own data and does **not** share a key with `Regata`, even though the same race may appear in both boards (worded slightly differently). An event here lists podium **rows** (boat, skipper, club) grouped by **class**; an event with no published standings is marked **pending**.
 
 ## Audio
 
 ### Narração
-The spoken-word version of a blog **Post**: an MP3 synthesized from the post's text in Alexandre's cloned voice, played from the **Ouvir control** on the post's date line. Pre-generated when the post is published/edited and served as a static file; not produced at read time. _Avoid_: podcast, audiobook, gravação.
+
+The spoken-word version of a blog **Post**: an audio file synthesized from the post's text in Alexandre's cloned voice, played from the **Ouvir control** on the post's date line. Pre-generated when the post is published/edited and served as a static file; not produced at read time. _Avoid_: podcast, audiobook, gravação.
 
 ### Voz clonada
-Alexandre's voice reproduced by a third-party TTS provider's voice-cloning model — the single voice that reads every **Narração**, in both pt and en. The provider is accessed behind a swappable adapter, so "Voz clonada" names the voice, not any one vendor. _Avoid_: gravação (implies a hand-recorded human take, which this is not).
+
+Alexandre's voice reproduced by a voice-cloning model — the single voice that reads every **Narração**, in both pt and en. Currently synthesized by a local [Voicebox](https://github.com/jamiepine/voicebox) instance, reached behind a swappable adapter, so "Voz clonada" names the voice, not any one engine. _Avoid_: gravação (implies a hand-recorded human take, which this is not).
 
 ### Ouvir control
+
 The compact play/pause button shown inline on a blog post's date line that plays the post's **Narração**. Present only when a Narração exists for that post.
 
 ## Relationships

--- a/docs/adr/0002-pre-generated-post-narration.md
+++ b/docs/adr/0002-pre-generated-post-narration.md
@@ -1,0 +1,17 @@
+# Blog post narration is pre-generated static audio, not synthesized on demand
+
+Each blog **Post** can be played as a **Narração** — an MP3 read in Alexandre's **Voz clonada**. We decided to pre-generate these MP3s with a local `npm run tts` script and commit them under `public/audio/`, served as plain static files, rather than synthesizing audio on demand from a serverless function at read time.
+
+## Considered Options
+
+- **On-demand serverless synthesis** (call the TTS API when the reader presses play). Rejected: it would convert the static (SSG) site into a server build (Vercel adapter + `output: "server"`), charge per play (and per repeated play / abuse), require a TTS API key inside a function, and add first-play latency.
+- **Pre-generated static MP3** (chosen). The site stays SSG, there is zero per-play cost, no API key reaches the client or any runtime, and playback is instant. Cost: audio must be regenerated when a post's text changes (handled by a content-hash manifest at `public/audio/manifest.json`) and the MP3s grow the repo.
+- **External storage (Vercel Blob / S3) vs. git.** Chose committing to `public/audio/` for zero infrastructure and no credentials; revisit only if the repo gets heavy.
+- **Provider lock-in.** Synthesis sits behind a swappable adapter (`synthesize(text, voice) → audio`); it ships as a stub and a concrete vendor (ElevenLabs, PlayHT, …) is wired in later via environment variables.
+
+## Consequences
+
+- A future reader sees committed MP3s, a `manifest.json`, and a stub adapter, and might wonder why we don't call a TTS API at runtime or use the browser Web Speech API — this record is the answer.
+- `npm run tts` is a manual publish-time chore, deliberately **not** part of `astro build` (which would re-pay synthesis on every build). It only (re)generates posts that are new or whose text hash changed.
+- Narration is **blog-only**; `estudo`, `code`, and `vela` have no date line and therefore no **Ouvir control** and no Narração.
+- The TTS API key lives only in the local environment / generation script and must never reach a client bundle.

--- a/docs/adr/0002-pre-generated-post-narration.md
+++ b/docs/adr/0002-pre-generated-post-narration.md
@@ -1,17 +1,18 @@
 # Blog post narration is pre-generated static audio, not synthesized on demand
 
-Each blog **Post** can be played as a **Narração** — an MP3 read in Alexandre's **Voz clonada**. We decided to pre-generate these MP3s with a local `npm run tts` script and commit them under `public/audio/`, served as plain static files, rather than synthesizing audio on demand from a serverless function at read time.
+Each blog **Post** can be played as a **Narração** — audio read in Alexandre's **Voz clonada**. We decided to pre-generate these files with a local `npm run tts` script and commit them under `public/audio/`, served as plain static files, rather than synthesizing audio on demand from a serverless function at read time. Synthesis is done by a **local [Voicebox](https://github.com/jamiepine/voicebox) instance** (its REST API on `127.0.0.1:17493`), not a cloud TTS provider.
 
 ## Considered Options
 
 - **On-demand serverless synthesis** (call the TTS API when the reader presses play). Rejected: it would convert the static (SSG) site into a server build (Vercel adapter + `output: "server"`), charge per play (and per repeated play / abuse), require a TTS API key inside a function, and add first-play latency.
-- **Pre-generated static MP3** (chosen). The site stays SSG, there is zero per-play cost, no API key reaches the client or any runtime, and playback is instant. Cost: audio must be regenerated when a post's text changes (handled by a content-hash manifest at `public/audio/manifest.json`) and the MP3s grow the repo.
+- **Pre-generated static audio** (chosen). The site stays SSG, there is zero per-play cost, nothing reaches the client or any runtime beyond the audio file, and playback is instant. Cost: audio must be regenerated when a post's text changes (handled by a content-hash manifest at `public/audio/manifest.json`) and the files grow the repo.
 - **External storage (Vercel Blob / S3) vs. git.** Chose committing to `public/audio/` for zero infrastructure and no credentials; revisit only if the repo gets heavy.
-- **Provider lock-in.** Synthesis sits behind a swappable adapter (`synthesize(text, voice) → audio`); it ships as a stub and a concrete vendor (ElevenLabs, PlayHT, …) is wired in later via environment variables.
+- **Local Voicebox vs. a cloud TTS provider** (ElevenLabs, PlayHT, …). Chose local Voicebox: the voice clone and synthesis stay on Alexandre's machine, with no API key, no usage cost, and no third party. Synthesis still sits behind a swappable `TtsAdapter`, so a different engine can replace it without touching the rest of the pipeline. Cost: generating requires Voicebox to be running locally, so it is a deliberately manual step.
 
 ## Consequences
 
-- A future reader sees committed MP3s, a `manifest.json`, and a stub adapter, and might wonder why we don't call a TTS API at runtime or use the browser Web Speech API — this record is the answer.
-- `npm run tts` is a manual publish-time chore, deliberately **not** part of `astro build` (which would re-pay synthesis on every build). It only (re)generates posts that are new or whose text hash changed.
+- A future reader sees committed audio, a `manifest.json`, and a Voicebox HTTP adapter, and might wonder why we don't call a TTS API at runtime or use the browser Web Speech API — this record is the answer.
+- `npm run tts` is a manual publish-time chore, deliberately **not** part of `astro build` (it needs the local Voicebox app running, and building shouldn't re-synthesize). It only (re)generates posts that are new or whose text hash changed.
+- The committed file format follows whatever Voicebox returns (mp3/wav/ogg); the manifest records each post's extension and the page builds the audio URL from it.
 - Narration is **blog-only**; `estudo`, `code`, and `vela` have no date line and therefore no **Ouvir control** and no Narração.
-- The TTS API key lives only in the local environment / generation script and must never reach a client bundle.
+- `VOICEBOX_PROFILE_ID` (the cloned voice) and `VOICEBOX_URL` configure generation; they live only in the local environment, never in a client bundle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,13 +40,16 @@
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^8.57.1",
         "eslint-plugin-astro": "^0.31.4",
+        "gray-matter": "^4.0.3",
         "husky": "^8.0.3",
         "lint-staged": "^15.5.2",
         "prettier": "^3.6.2",
         "prettier-plugin-astro": "^0.13.0",
         "prettier-plugin-tailwindcss": "^0.5.14",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "tsx": "^4.22.4",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3322,6 +3325,13 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/core": {
       "version": "1.3.101",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.101.tgz",
@@ -3610,6 +3620,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
@@ -3629,6 +3650,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3966,6 +3994,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/kit": {
@@ -4307,6 +4448,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -5431,6 +5582,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -7082,6 +7243,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -7202,11 +7377,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -7799,6 +7997,46 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/h3": {
       "version": "1.15.4",
@@ -8693,6 +8931,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9001,6 +9249,16 @@
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -10831,6 +11089,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -11328,6 +11600,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
       "version": "4.10.38",
@@ -12727,6 +13006,20 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -12826,6 +13119,13 @@
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -13027,6 +13327,27 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
@@ -13137,6 +13458,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -13657,6 +13988,13 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -13709,6 +14047,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/titleize": {
@@ -13829,6 +14177,483 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -14264,7 +15089,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -14340,7 +15164,6 @@
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -14359,7 +15182,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14384,6 +15206,116 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/volar-service-css": {
@@ -14677,6 +15609,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "format": "prettier --write . --plugin=prettier-plugin-astro",
     "cz": "cz",
     "prepare": "husky install",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "tts": "tsx scripts/generate-narration.ts"
   },
   "dependencies": {
     "@astrojs/check": "^0.5.10",
@@ -47,13 +50,16 @@
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.57.1",
     "eslint-plugin-astro": "^0.31.4",
+    "gray-matter": "^4.0.3",
     "husky": "^8.0.3",
     "lint-staged": "^15.5.2",
     "prettier": "^3.6.2",
     "prettier-plugin-astro": "^0.13.0",
     "prettier-plugin-tailwindcss": "^0.5.14",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "tsx": "^4.22.4",
+    "vitest": "^4.1.9"
   },
   "config": {
     "commitizen": {

--- a/scripts/generate-narration.ts
+++ b/scripts/generate-narration.ts
@@ -1,0 +1,117 @@
+/**
+ * Pre-generate the Narração (spoken-word MP3) for each blog Post.
+ *
+ * Run manually at publish time: `npm run tts` (add `--force` to regenerate
+ * everything). It reads the `blog` collection, extracts each post's spoken
+ * text, and (re)generates only the posts that are new or whose text changed
+ * (tracked by hash in public/audio/manifest.json). MP3s are written to
+ * public/audio/<slug>.mp3 and served as static files.
+ *
+ * Until a TTS provider is wired into synthesize.ts this runs as a dry run,
+ * printing what it would generate. Deliberately NOT part of `astro build`.
+ */
+import {
+  readdirSync,
+  readFileSync,
+  existsSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { join, extname, basename } from "node:path";
+import matter from "gray-matter";
+import { extractNarrationText } from "../src/utils/narration/extractNarrationText";
+import {
+  planNarration,
+  hashNarrationText,
+  type NarrationManifest,
+  type NarrationPost,
+} from "../src/utils/narration/narrationManifest";
+import { getTtsAdapter, VOICE_ID } from "../src/utils/narration/synthesize";
+
+const ROOT = process.cwd();
+const BLOG_DIR = join(ROOT, "src/content/blog");
+const AUDIO_DIR = join(ROOT, "public/audio");
+const MANIFEST_PATH = join(AUDIO_DIR, "manifest.json");
+
+const force = process.argv.includes("--force");
+
+const audioPath = (slug: string) => join(AUDIO_DIR, `${slug}.mp3`);
+
+function loadManifest(): NarrationManifest {
+  if (!existsSync(MANIFEST_PATH)) return {};
+  try {
+    return JSON.parse(readFileSync(MANIFEST_PATH, "utf8")) as NarrationManifest;
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  const files = readdirSync(BLOG_DIR).filter((f) =>
+    [".md", ".mdx"].includes(extname(f)),
+  );
+
+  const posts: (NarrationPost & { text: string })[] = [];
+  for (const file of files) {
+    const { data, content } = matter(
+      readFileSync(join(BLOG_DIR, file), "utf8"),
+    );
+    if (data.draft) continue; // drafts have no page, so no Narração
+    const slug: string = data.slug ?? basename(file, extname(file));
+    const title: string = data.title ?? slug;
+    const text = extractNarrationText({ title, body: content });
+    posts.push({
+      slug,
+      hash: hashNarrationText(text),
+      hasAudio: existsSync(audioPath(slug)),
+      text,
+    });
+  }
+
+  const manifest = loadManifest();
+  const { decisions, nextManifest } = planNarration(posts, manifest, { force });
+  const work = decisions.filter((d) => d.action !== "skip");
+
+  console.log(
+    `Blog posts: ${decisions.length} | to (re)generate: ${work.length} | up to date: ${decisions.length - work.length}`,
+  );
+
+  const adapter = getTtsAdapter();
+
+  if (!adapter.configured) {
+    console.log(`\nTTS adapter "${adapter.name}" is not configured — dry run.`);
+    for (const d of work) console.log(`  would ${d.action}: ${d.slug}.mp3`);
+    console.log(
+      "\nWire a provider in src/utils/narration/synthesize.ts (and set TTS_VOICE_ID), then re-run `npm run tts`.",
+    );
+    return;
+  }
+
+  if (!VOICE_ID) {
+    console.error("TTS_VOICE_ID is not set. Aborting.");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (work.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  mkdirSync(AUDIO_DIR, { recursive: true });
+  for (const d of work) {
+    const post = posts.find((p) => p.slug === d.slug)!;
+    process.stdout.write(`  ${d.action}: ${d.slug}.mp3 … `);
+    const audio = await adapter.synthesize(post.text, VOICE_ID);
+    writeFileSync(audioPath(d.slug), audio);
+    console.log("done");
+  }
+
+  writeFileSync(MANIFEST_PATH, JSON.stringify(nextManifest, null, 2) + "\n");
+  console.log(`\nManifest updated: ${MANIFEST_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/generate-narration.ts
+++ b/scripts/generate-narration.ts
@@ -1,14 +1,19 @@
 /**
- * Pre-generate the Narração (spoken-word MP3) for each blog Post.
+ * Pre-generate the Narração (spoken-word audio) for each blog Post using a
+ * local Voicebox instance (https://github.com/jamiepine/voicebox).
  *
- * Run manually at publish time: `npm run tts` (add `--force` to regenerate
- * everything). It reads the `blog` collection, extracts each post's spoken
- * text, and (re)generates only the posts that are new or whose text changed
- * (tracked by hash in public/audio/manifest.json). MP3s are written to
- * public/audio/<slug>.mp3 and served as static files.
+ * Run manually at publish time:
+ *   npm run tts                 # generate what's new/changed
+ *   npm run tts -- --force      # regenerate everything
+ *   npm run tts -- --dry-run    # list work without calling Voicebox
  *
- * Until a TTS provider is wired into synthesize.ts this runs as a dry run,
- * printing what it would generate. Deliberately NOT part of `astro build`.
+ * It reads the `blog` collection, extracts each post's spoken text, and
+ * (re)generates only posts that are new or whose text changed (tracked by hash
+ * in public/audio/manifest.json). Audio is written to public/audio/<slug>.<ext>
+ * and served as a static file. Deliberately NOT part of `astro build`.
+ *
+ * Requires Voicebox running and VOICEBOX_PROFILE_ID set to the cloned voice's
+ * profile id (find it via `curl http://127.0.0.1:17493/profiles`).
  */
 import {
   readdirSync,
@@ -26,7 +31,7 @@ import {
   type NarrationManifest,
   type NarrationPost,
 } from "../src/utils/narration/narrationManifest";
-import { getTtsAdapter, VOICE_ID } from "../src/utils/narration/synthesize";
+import { getTtsAdapter } from "../src/utils/narration/synthesize";
 
 const ROOT = process.cwd();
 const BLOG_DIR = join(ROOT, "src/content/blog");
@@ -34,8 +39,10 @@ const AUDIO_DIR = join(ROOT, "public/audio");
 const MANIFEST_PATH = join(AUDIO_DIR, "manifest.json");
 
 const force = process.argv.includes("--force");
+const dryRun = process.argv.includes("--dry-run");
 
-const audioPath = (slug: string) => join(AUDIO_DIR, `${slug}.mp3`);
+const audioPath = (slug: string, ext: string) =>
+  join(AUDIO_DIR, `${slug}.${ext}`);
 
 function loadManifest(): NarrationManifest {
   if (!existsSync(MANIFEST_PATH)) return {};
@@ -46,12 +53,16 @@ function loadManifest(): NarrationManifest {
   }
 }
 
+type PostWithText = NarrationPost & { text: string; language: string };
+
 async function main() {
+  const manifest = loadManifest();
+
   const files = readdirSync(BLOG_DIR).filter((f) =>
     [".md", ".mdx"].includes(extname(f)),
   );
 
-  const posts: (NarrationPost & { text: string })[] = [];
+  const posts: PostWithText[] = [];
   for (const file of files) {
     const { data, content } = matter(
       readFileSync(join(BLOG_DIR, file), "utf8"),
@@ -60,16 +71,19 @@ async function main() {
     const slug: string = data.slug ?? basename(file, extname(file));
     const title: string = data.title ?? slug;
     const text = extractNarrationText({ title, body: content });
+    // An audio file exists if the manifest's recorded extension is on disk.
+    const knownExt = manifest[slug]?.ext;
+    const hasAudio = knownExt ? existsSync(audioPath(slug, knownExt)) : false;
     posts.push({
       slug,
       hash: hashNarrationText(text),
-      hasAudio: existsSync(audioPath(slug)),
+      hasAudio,
       text,
+      language: data.language === "pt" ? "pt" : "en",
     });
   }
 
-  const manifest = loadManifest();
-  const { decisions, nextManifest } = planNarration(posts, manifest, { force });
+  const { decisions } = planNarration(posts, manifest, { force });
   const work = decisions.filter((d) => d.action !== "skip");
 
   console.log(
@@ -78,18 +92,17 @@ async function main() {
 
   const adapter = getTtsAdapter();
 
-  if (!adapter.configured) {
-    console.log(`\nTTS adapter "${adapter.name}" is not configured — dry run.`);
-    for (const d of work) console.log(`  would ${d.action}: ${d.slug}.mp3`);
-    console.log(
-      "\nWire a provider in src/utils/narration/synthesize.ts (and set TTS_VOICE_ID), then re-run `npm run tts`.",
-    );
-    return;
-  }
-
-  if (!VOICE_ID) {
-    console.error("TTS_VOICE_ID is not set. Aborting.");
-    process.exitCode = 1;
+  if (dryRun || !adapter.configured) {
+    const why = dryRun
+      ? "--dry-run"
+      : `adapter "${adapter.name}" is not configured (set VOICEBOX_PROFILE_ID)`;
+    console.log(`\nDry run (${why}).`);
+    for (const d of work) console.log(`  would ${d.action}: ${d.slug}`);
+    if (!adapter.configured && !dryRun) {
+      console.log(
+        "\nStart Voicebox and set VOICEBOX_PROFILE_ID (see `curl http://127.0.0.1:17493/profiles`), then re-run `npm run tts`.",
+      );
+    }
     return;
   }
 
@@ -98,13 +111,20 @@ async function main() {
     return;
   }
 
+  // Build the manifest to commit, carrying over unchanged entries.
+  const nextManifest: NarrationManifest = {};
+  for (const post of posts) nextManifest[post.slug] = manifest[post.slug];
+
   mkdirSync(AUDIO_DIR, { recursive: true });
   for (const d of work) {
     const post = posts.find((p) => p.slug === d.slug)!;
-    process.stdout.write(`  ${d.action}: ${d.slug}.mp3 … `);
-    const audio = await adapter.synthesize(post.text, VOICE_ID);
-    writeFileSync(audioPath(d.slug), audio);
-    console.log("done");
+    process.stdout.write(`  ${d.action}: ${d.slug} … `);
+    const { data, extension } = await adapter.synthesize(post.text, {
+      language: post.language,
+    });
+    writeFileSync(audioPath(d.slug, extension), data);
+    nextManifest[d.slug] = { hash: post.hash, ext: extension };
+    console.log(`done (${extension}, ${(data.length / 1024).toFixed(0)} KB)`);
   }
 
   writeFileSync(MANIFEST_PATH, JSON.stringify(nextManifest, null, 2) + "\n");

--- a/src/components/ListenButton.tsx
+++ b/src/components/ListenButton.tsx
@@ -2,8 +2,8 @@ import { useRef, useState } from "react";
 import { Pause, Play } from "lucide-react";
 
 interface Props {
-  /** Post slug; the Narração is served from /audio/<slug>.mp3. */
-  slug: string;
+  /** URL of the post's Narração audio file (e.g. /audio/<slug>.mp3). */
+  src: string;
   /** Post language, used to localize the control label. */
   lang?: "pt" | "en";
 }
@@ -15,9 +15,9 @@ const LABELS = {
 
 /**
  * The Ouvir control: a compact play/pause button that plays a post's Narração.
- * Rendered only when an MP3 exists for the post (the layout decides that).
+ * Rendered only when audio exists for the post (the layout decides that).
  */
-export default function ListenButton({ slug, lang = "en" }: Props) {
+export default function ListenButton({ src, lang = "en" }: Props) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const [playing, setPlaying] = useState(false);
   const labels = LABELS[lang] ?? LABELS.en;
@@ -51,7 +51,7 @@ export default function ListenButton({ slug, lang = "en" }: Props) {
       </button>
       <audio
         ref={audioRef}
-        src={`/audio/${slug}.mp3`}
+        src={src}
         preload="none"
         onPlay={() => setPlaying(true)}
         onPause={() => setPlaying(false)}

--- a/src/components/ListenButton.tsx
+++ b/src/components/ListenButton.tsx
@@ -1,0 +1,62 @@
+import { useRef, useState } from "react";
+import { Pause, Play } from "lucide-react";
+
+interface Props {
+  /** Post slug; the Narração is served from /audio/<slug>.mp3. */
+  slug: string;
+  /** Post language, used to localize the control label. */
+  lang?: "pt" | "en";
+}
+
+const LABELS = {
+  pt: { play: "Ouvir", pause: "Pausa" },
+  en: { play: "Listen", pause: "Pause" },
+} as const;
+
+/**
+ * The Ouvir control: a compact play/pause button that plays a post's Narração.
+ * Rendered only when an MP3 exists for the post (the layout decides that).
+ */
+export default function ListenButton({ slug, lang = "en" }: Props) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+  const labels = LABELS[lang] ?? LABELS.en;
+  const label = playing ? labels.pause : labels.play;
+
+  const toggle = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      void audio.play();
+    } else {
+      audio.pause();
+    }
+  };
+
+  return (
+    <span className="inline-flex items-center">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-pressed={playing}
+        aria-label={label}
+        className="focus-outline inline-flex items-center gap-1 text-sm hover:opacity-75"
+      >
+        {playing ? (
+          <Pause className="h-4 w-4" aria-hidden="true" />
+        ) : (
+          <Play className="h-4 w-4" aria-hidden="true" />
+        )}
+        <span>{label}</span>
+      </button>
+      <audio
+        ref={audioRef}
+        src={`/audio/${slug}.mp3`}
+        preload="none"
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+      />
+    </span>
+  );
+}

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -4,18 +4,26 @@ import Header from "@components/Header.astro";
 import Footer from "@components/Footer.astro";
 import Tag from "@components/Tag.astro";
 import Datetime from "@components/Datetime";
+import ListenButton from "@components/ListenButton";
 import type { CollectionEntry } from "astro:content";
 import { slugifyStr } from "@utils/slugify";
 import ShareLinks from "@components/ShareLinks.astro";
 import { SITE } from "@config";
 import BlogPostingSchema from "@components/schema/BlogPostingSchema.astro";
 import BreadcrumbSchema from "@components/schema/BreadcrumbSchema.astro";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 export interface Props {
   post: CollectionEntry<"blog">;
 }
 
 const { post } = Astro.props;
+
+// The Ouvir control only appears when this post has a pre-generated Narração.
+const hasNarration = existsSync(
+  join(process.cwd(), "public", "audio", `${post.slug}.mp3`),
+);
 
 const {
   title,
@@ -33,7 +41,7 @@ const { Content } = await post.render();
 const ogImageUrl = typeof ogImage === "string" ? ogImage : ogImage?.src;
 const ogUrl = new URL(
   ogImageUrl ?? `/posts/${slugifyStr(title)}.png`,
-  Astro.url.origin
+  Astro.url.origin,
 ).href;
 
 const layoutProps = {
@@ -58,11 +66,13 @@ const layoutProps = {
     image={ogUrl}
     tags={tags}
   />
-  <BreadcrumbSchema items={[
-    { name: "Home", url: "/" },
-    { name: "Posts", url: "/posts/" },
-    { name: title }
-  ]} />
+  <BreadcrumbSchema
+    items={[
+      { name: "Home", url: "/" },
+      { name: "Posts", url: "/posts/" },
+      { name: title },
+    ]}
+  />
   <Header />
 
   <!-- <div class="progress-container fixed top-0 z-10 h-1 w-full bg-skin-fill">
@@ -83,18 +93,24 @@ const layoutProps = {
   </div>
   <main id="main-content">
     <h1 transition:name={slugifyStr(title)} class="post-title">{title}</h1>
-    <Datetime
-      pubDatetime={pubDatetime}
-      modDatetime={modDatetime}
-      size="lg"
-      className="my-2"
-    />
+    <div class="my-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+      <Datetime pubDatetime={pubDatetime} modDatetime={modDatetime} size="lg" />
+      {
+        hasNarration && (
+          <ListenButton
+            slug={post.slug}
+            lang={post.data.language}
+            client:idle
+          />
+        )
+      }
+    </div>
     <article id="article" role="article" class="prose mx-auto mt-8 max-w-3xl">
       <Content />
     </article>
 
     <ul class="my-8">
-      {tags.map(tag => <Tag tag={slugifyStr(tag)} />)}
+      {tags.map((tag) => <Tag tag={slugifyStr(tag)} />)}
     </ul>
 
     <div

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -11,7 +11,7 @@ import ShareLinks from "@components/ShareLinks.astro";
 import { SITE } from "@config";
 import BlogPostingSchema from "@components/schema/BlogPostingSchema.astro";
 import BreadcrumbSchema from "@components/schema/BreadcrumbSchema.astro";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 export interface Props {
@@ -21,9 +21,22 @@ export interface Props {
 const { post } = Astro.props;
 
 // The Ouvir control only appears when this post has a pre-generated Narração.
-const hasNarration = existsSync(
-  join(process.cwd(), "public", "audio", `${post.slug}.mp3`),
-);
+// The audio manifest (written by `npm run tts`) records each post's file
+// extension, so the URL follows whatever format Voicebox produced.
+const narrationSrc = (() => {
+  const manifestPath = join(process.cwd(), "public", "audio", "manifest.json");
+  if (!existsSync(manifestPath)) return null;
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as Record<
+      string,
+      { ext?: string }
+    >;
+    const ext = manifest[post.slug]?.ext;
+    return ext ? `/audio/${post.slug}.${ext}` : null;
+  } catch {
+    return null;
+  }
+})();
 
 const {
   title,
@@ -96,9 +109,9 @@ const layoutProps = {
     <div class="my-2 flex flex-wrap items-center gap-x-3 gap-y-1">
       <Datetime pubDatetime={pubDatetime} modDatetime={modDatetime} size="lg" />
       {
-        hasNarration && (
+        narrationSrc && (
           <ListenButton
-            slug={post.slug}
+            src={narrationSrc}
             lang={post.data.language}
             client:idle
           />

--- a/src/utils/narration/extractNarrationText.test.ts
+++ b/src/utils/narration/extractNarrationText.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { extractNarrationText } from "./extractNarrationText";
+
+describe("extractNarrationText", () => {
+  it("reads the title first, then the prose", () => {
+    const out = extractNarrationText({
+      title: "O Fim da IA Centralizada",
+      body: "A primeira frase do artigo.",
+    });
+    expect(out).toBe("O Fim da IA Centralizada. A primeira frase do artigo.");
+  });
+
+  it("does not duplicate terminal punctuation after the title", () => {
+    const out = extractNarrationText({ title: "Olá!", body: "Corpo." });
+    expect(out).toBe("Olá. Corpo.");
+  });
+
+  it("omits fenced code blocks entirely", () => {
+    const body = [
+      "Antes do código.",
+      "",
+      "```js",
+      "const x = 1;",
+      "console.log(x);",
+      "```",
+      "",
+      "Depois do código.",
+    ].join("\n");
+    const out = extractNarrationText({ title: "T", body });
+    expect(out).not.toContain("const x");
+    expect(out).not.toContain("console.log");
+    expect(out).toBe("T. Antes do código. Depois do código.");
+  });
+
+  it("keeps inline code as its literal text", () => {
+    const out = extractNarrationText({
+      title: "T",
+      body: "Usa `npm run tts` agora.",
+    });
+    expect(out).toBe("T. Usa npm run tts agora.");
+  });
+
+  it("drops the auto-generated table of contents heading", () => {
+    const body = ["## Table of contents", "", "Conteúdo real."].join("\n");
+    const out = extractNarrationText({ title: "T", body });
+    expect(out.toLowerCase()).not.toContain("table of contents");
+    expect(out).toBe("T. Conteúdo real.");
+  });
+
+  it("removes images but keeps surrounding prose", () => {
+    const body = "Veja ![diagrama](https://example.com/a.png) aqui.";
+    const out = extractNarrationText({ title: "T", body });
+    expect(out).toBe("T. Veja aqui.");
+  });
+
+  it("keeps link text and drops the url", () => {
+    const out = extractNarrationText({
+      title: "T",
+      body: "Veja a [topologia](https://pt.wikipedia.org/wiki/x) da rede.",
+    });
+    expect(out).toBe("T. Veja a topologia da rede.");
+  });
+
+  it("strips bare urls", () => {
+    const out = extractNarrationText({
+      title: "T",
+      body: "Fonte: https://example.com/page acabou.",
+    });
+    expect(out).toBe("T. Fonte: acabou.");
+  });
+
+  it("removes emphasis, heading and list markers", () => {
+    const body = [
+      "# Secção",
+      "",
+      "Texto **forte** e _suave_.",
+      "",
+      "- primeiro",
+      "- segundo",
+    ].join("\n");
+    const out = extractNarrationText({ title: "T", body });
+    expect(out).toBe("T. Secção Texto forte e suave. primeiro segundo");
+  });
+
+  it("collapses blank lines and stray whitespace", () => {
+    const body = "Uma   frase.\n\n\n\nOutra frase.";
+    const out = extractNarrationText({ title: "T", body });
+    expect(out).toBe("T. Uma frase. Outra frase.");
+  });
+});

--- a/src/utils/narration/extractNarrationText.ts
+++ b/src/utils/narration/extractNarrationText.ts
@@ -1,0 +1,64 @@
+export interface NarrationSource {
+  title: string;
+  /** Raw markdown body of the post, without frontmatter. */
+  body: string;
+}
+
+/**
+ * Turn a blog post into the plain text its Narração speaks.
+ *
+ * The post title is read first, then the prose. Code blocks are omitted
+ * entirely (no spoken placeholder), the auto-generated "Table of contents"
+ * heading, images and raw URLs are stripped, and inline code is kept as its
+ * literal text. The result is clean, continuous text with no markdown syntax.
+ *
+ * Pure and deterministic: same input, same output, no I/O.
+ */
+export function extractNarrationText({ title, body }: NarrationSource): string {
+  let text = body;
+
+  // Fenced code blocks (``` or ~~~) — dropped completely.
+  text = text.replace(/^[ \t]*(```|~~~)[\s\S]*?^[ \t]*\1[ \t]*$/gm, "");
+
+  // The remark-toc / remark-collapse "Table of contents" heading. The list
+  // itself is injected at build time, so only the heading exists in source.
+  text = text.replace(/^#{1,6}\s*table of contents.*$/gim, "");
+
+  // Images: ![alt](url) — dropped.
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, "");
+
+  // Links: [text](url) — keep the text.
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  // Inline code: `foo` — keep as foo.
+  text = text.replace(/`([^`]+)`/g, "$1");
+
+  // Heading markers — keep the heading text as a sentence.
+  text = text.replace(/^#{1,6}\s+/gm, "");
+
+  // Blockquote markers.
+  text = text.replace(/^\s*>\s?/gm, "");
+
+  // List markers at the start of a line.
+  text = text.replace(/^\s*([-*+]|\d+\.)\s+/gm, "");
+
+  // Emphasis / strikethrough markers.
+  text = text.replace(/(\*\*|\*|__|_|~~)/g, "");
+
+  // Raw HTML tags.
+  text = text.replace(/<[^>]+>/g, "");
+
+  // Bare URLs.
+  text = text.replace(/https?:\/\/\S+/g, "");
+
+  // Collapse whitespace into single-spaced continuous prose.
+  text = text
+    .replace(/[ \t]+/g, " ")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" ");
+
+  const cleanTitle = title.trim().replace(/[.!?]+$/, "");
+  return `${cleanTitle}. ${text}`.trim();
+}

--- a/src/utils/narration/narrationManifest.test.ts
+++ b/src/utils/narration/narrationManifest.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  planNarration,
+  hashNarrationText,
+  type NarrationManifest,
+} from "./narrationManifest";
+
+const post = (slug: string, hash: string, hasAudio: boolean) => ({
+  slug,
+  hash,
+  hasAudio,
+});
+
+describe("planNarration", () => {
+  it("generates when there is no manifest entry", () => {
+    const { decisions } = planNarration([post("a", "h1", false)], {});
+    expect(decisions).toEqual([{ slug: "a", action: "generate" }]);
+  });
+
+  it("generates when the manifest entry exists but the mp3 is missing", () => {
+    const manifest: NarrationManifest = { a: { hash: "h1" } };
+    const { decisions } = planNarration([post("a", "h1", false)], manifest);
+    expect(decisions).toEqual([{ slug: "a", action: "generate" }]);
+  });
+
+  it("regenerates when the text hash changed", () => {
+    const manifest: NarrationManifest = { a: { hash: "old" } };
+    const { decisions } = planNarration([post("a", "new", true)], manifest);
+    expect(decisions).toEqual([{ slug: "a", action: "regenerate" }]);
+  });
+
+  it("skips when hash matches and the mp3 exists", () => {
+    const manifest: NarrationManifest = { a: { hash: "h1" } };
+    const { decisions } = planNarration([post("a", "h1", true)], manifest);
+    expect(decisions).toEqual([{ slug: "a", action: "skip" }]);
+  });
+
+  it("forces (re)generation of every post regardless of hash", () => {
+    const manifest: NarrationManifest = { a: { hash: "h1" } };
+    const { decisions } = planNarration(
+      [post("a", "h1", true), post("b", "h2", false)],
+      manifest,
+      { force: true },
+    );
+    expect(decisions).toEqual([
+      { slug: "a", action: "regenerate" },
+      { slug: "b", action: "generate" },
+    ]);
+  });
+
+  it("writes the current hash into nextManifest for every post", () => {
+    const { nextManifest } = planNarration(
+      [post("a", "h1", true), post("b", "h2", false)],
+      { a: { hash: "h1" } },
+    );
+    expect(nextManifest).toEqual({ a: { hash: "h1" }, b: { hash: "h2" } });
+  });
+
+  it("prunes manifest entries for posts that no longer exist", () => {
+    const manifest: NarrationManifest = {
+      gone: { hash: "x" },
+      a: { hash: "h1" },
+    };
+    const { nextManifest } = planNarration([post("a", "h1", true)], manifest);
+    expect(nextManifest).toEqual({ a: { hash: "h1" } });
+    expect(nextManifest.gone).toBeUndefined();
+  });
+});
+
+describe("hashNarrationText", () => {
+  it("is stable for the same text and differs for different text", () => {
+    expect(hashNarrationText("hello")).toBe(hashNarrationText("hello"));
+    expect(hashNarrationText("hello")).not.toBe(hashNarrationText("world"));
+  });
+});

--- a/src/utils/narration/narrationManifest.ts
+++ b/src/utils/narration/narrationManifest.ts
@@ -1,0 +1,75 @@
+import { createHash } from "node:crypto";
+
+export interface ManifestEntry {
+  /** Hash of the spoken text the MP3 was generated from. */
+  hash: string;
+}
+
+/** Maps a post slug to the state of its committed Narração. */
+export type NarrationManifest = Record<string, ManifestEntry>;
+
+export interface NarrationPost {
+  slug: string;
+  /** Hash of this post's current spoken text (see hashNarrationText). */
+  hash: string;
+  /** Whether an MP3 already exists on disk for this slug. */
+  hasAudio: boolean;
+}
+
+export type NarrationAction = "generate" | "regenerate" | "skip";
+
+export interface NarrationDecision {
+  slug: string;
+  action: NarrationAction;
+}
+
+export interface NarrationPlan {
+  decisions: NarrationDecision[];
+  /** The manifest as it should be once the planned work has run. */
+  nextManifest: NarrationManifest;
+}
+
+/** Stable content hash over the spoken text. */
+export function hashNarrationText(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/**
+ * Decide which posts need their Narração (re)generated.
+ *
+ * - missing manifest entry or missing MP3  → generate
+ * - text hash changed since last run       → regenerate
+ * - otherwise                              → skip
+ *
+ * With `force`, every post is (re)generated regardless of hash. The returned
+ * `nextManifest` contains only the supplied posts, so entries for deleted
+ * posts are pruned. Pure: no I/O, decision derived solely from the inputs.
+ */
+export function planNarration(
+  posts: NarrationPost[],
+  manifest: NarrationManifest,
+  options: { force?: boolean } = {},
+): NarrationPlan {
+  const decisions: NarrationDecision[] = [];
+  const nextManifest: NarrationManifest = {};
+
+  for (const post of posts) {
+    const previous = manifest[post.slug];
+    let action: NarrationAction;
+
+    if (options.force) {
+      action = previous ? "regenerate" : "generate";
+    } else if (!previous || !post.hasAudio) {
+      action = "generate";
+    } else if (previous.hash !== post.hash) {
+      action = "regenerate";
+    } else {
+      action = "skip";
+    }
+
+    decisions.push({ slug: post.slug, action });
+    nextManifest[post.slug] = { hash: post.hash };
+  }
+
+  return { decisions, nextManifest };
+}

--- a/src/utils/narration/narrationManifest.ts
+++ b/src/utils/narration/narrationManifest.ts
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto";
 
 export interface ManifestEntry {
-  /** Hash of the spoken text the MP3 was generated from. */
+  /** Hash of the spoken text the audio was generated from. */
   hash: string;
+  /** Audio file extension Voicebox produced (mp3/wav/ogg). Filled by the
+   * generator after synthesis; absent for entries planned but not yet built. */
+  ext?: string;
 }
 
 /** Maps a post slug to the state of its committed Narração. */

--- a/src/utils/narration/synthesize.ts
+++ b/src/utils/narration/synthesize.ts
@@ -1,39 +1,110 @@
+import { readFileSync } from "node:fs";
+
 /**
- * Swappable boundary to the text-to-speech provider that renders a post's
- * text in Alexandre's Voz clonada. The concrete vendor (ElevenLabs, PlayHT, …)
- * is wired in later; until then `getTtsAdapter` returns a stub and narration
- * generation runs as a dry run.
+ * Swappable boundary to the engine that renders a post's text in Alexandre's
+ * Voz clonada. The current adapter talks to a **local Voicebox** instance
+ * (https://github.com/jamiepine/voicebox) over its REST API — everything runs
+ * on Alexandre's machine, so there is no cloud key and no per-use cost.
  *
- * The provider API key must stay in the local environment / generation script
- * and never reach a client bundle.
+ * Voicebox must be running (default http://127.0.0.1:17493) and the cloned
+ * voice's profile id supplied via VOICEBOX_PROFILE_ID when `npm run tts` runs.
  */
-export interface TtsAdapter {
-  readonly name: string;
-  /** False until a real provider is wired in. */
-  readonly configured: boolean;
-  /** Synthesize `text` in the given cloned voice, returning MP3 bytes. */
-  synthesize(text: string, voiceId: string): Promise<Buffer>;
+export type AudioExtension = "mp3" | "wav" | "ogg";
+
+export interface SynthResult {
+  data: Buffer;
+  /** Container format Voicebox returned, used as the file extension. */
+  extension: AudioExtension;
 }
 
-const stubAdapter: TtsAdapter = {
-  name: "stub",
-  configured: false,
-  async synthesize() {
-    throw new Error(
-      "No TTS provider configured. Wire a concrete adapter in " +
-        "src/utils/narration/synthesize.ts (provider API key + voice id) " +
-        "before generating narration audio.",
-    );
+export interface TtsAdapter {
+  readonly name: string;
+  /** False when the adapter lacks the config it needs (then we dry-run). */
+  readonly configured: boolean;
+  /** Synthesize `text` in the cloned voice for the given post language. */
+  synthesize(text: string, opts: { language: string }): Promise<SynthResult>;
+}
+
+const BASE_URL = (process.env.VOICEBOX_URL ?? "http://127.0.0.1:17493").replace(
+  /\/$/,
+  "",
+);
+const PROFILE_ID = process.env.VOICEBOX_PROFILE_ID ?? "";
+
+function extensionFromContentType(contentType: string): AudioExtension {
+  const ct = contentType.toLowerCase();
+  if (ct.includes("wav") || ct.includes("wave")) return "wav";
+  if (ct.includes("ogg")) return "ogg";
+  return "mp3"; // audio/mpeg and anything else default to mp3
+}
+
+const voiceboxAdapter: TtsAdapter = {
+  name: "voicebox",
+  // Reachability is checked at call time; config-completeness is the profile id.
+  configured: PROFILE_ID !== "",
+
+  async synthesize(text, { language }) {
+    let res: Response;
+    try {
+      res = await fetch(`${BASE_URL}/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text,
+          profile_id: PROFILE_ID,
+          language,
+          // Harmless if Voicebox ignores it; prefer mp3 when honoured.
+          format: "mp3",
+        }),
+      });
+    } catch (cause) {
+      throw new Error(
+        `Could not reach Voicebox at ${BASE_URL}. Is the app running? ` +
+          `Set VOICEBOX_URL to override the address.`,
+        { cause },
+      );
+    }
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(
+        `Voicebox /generate failed (${res.status} ${res.statusText}). ${detail}`.trim(),
+      );
+    }
+
+    const contentType = res.headers.get("content-type") ?? "";
+
+    // JSON response: look for base64 audio or a file path on disk.
+    if (contentType.includes("application/json")) {
+      const body = (await res.json()) as Record<string, unknown>;
+      const b64 = body.audio ?? body.audio_base64 ?? body.data;
+      if (typeof b64 === "string") {
+        return {
+          data: Buffer.from(b64, "base64"),
+          extension: extensionFromContentType(String(body.format ?? "")),
+        };
+      }
+      const path = body.path ?? body.file ?? body.output_path;
+      if (typeof path === "string") {
+        return {
+          data: readFileSync(path),
+          extension: extensionFromContentType(path),
+        };
+      }
+      throw new Error(
+        `Unexpected JSON from Voicebox /generate (keys: ${Object.keys(body).join(", ")}).`,
+      );
+    }
+
+    // Otherwise the body is the raw audio.
+    return {
+      data: Buffer.from(await res.arrayBuffer()),
+      extension: extensionFromContentType(contentType),
+    };
   },
 };
 
-/**
- * Returns the active TTS adapter. Replace the body with a concrete provider
- * adapter (guarded by its env vars) when one is chosen.
- */
+/** Returns the active TTS adapter. */
 export function getTtsAdapter(): TtsAdapter {
-  return stubAdapter;
+  return voiceboxAdapter;
 }
-
-/** The cloned-voice id for the chosen provider, supplied via the environment. */
-export const VOICE_ID = process.env.TTS_VOICE_ID ?? "";

--- a/src/utils/narration/synthesize.ts
+++ b/src/utils/narration/synthesize.ts
@@ -1,0 +1,39 @@
+/**
+ * Swappable boundary to the text-to-speech provider that renders a post's
+ * text in Alexandre's Voz clonada. The concrete vendor (ElevenLabs, PlayHT, …)
+ * is wired in later; until then `getTtsAdapter` returns a stub and narration
+ * generation runs as a dry run.
+ *
+ * The provider API key must stay in the local environment / generation script
+ * and never reach a client bundle.
+ */
+export interface TtsAdapter {
+  readonly name: string;
+  /** False until a real provider is wired in. */
+  readonly configured: boolean;
+  /** Synthesize `text` in the given cloned voice, returning MP3 bytes. */
+  synthesize(text: string, voiceId: string): Promise<Buffer>;
+}
+
+const stubAdapter: TtsAdapter = {
+  name: "stub",
+  configured: false,
+  async synthesize() {
+    throw new Error(
+      "No TTS provider configured. Wire a concrete adapter in " +
+        "src/utils/narration/synthesize.ts (provider API key + voice id) " +
+        "before generating narration audio.",
+    );
+  },
+};
+
+/**
+ * Returns the active TTS adapter. Replace the body with a concrete provider
+ * adapter (guarded by its env vars) when one is chosen.
+ */
+export function getTtsAdapter(): TtsAdapter {
+  return stubAdapter;
+}
+
+/** The cloned-voice id for the chosen provider, supplied via the environment. */
+export const VOICE_ID = process.env.TTS_VOICE_ID ?? "";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Implements #7.

## What

Adds a **Narração** to blog posts: a pre-generated audio file of the post read in Alexandre's **Voz clonada**, played from a compact **Ouvir control** (play/pause) inline on the post's date line.

Architecture follows [ADR 0002](docs/adr/0002-pre-generated-post-narration.md): audio is pre-generated at publish time and served as static files (the site stays SSG — no serverless, no per-play cost). Synthesis is done by a **local [Voicebox](https://github.com/jamiepine/voicebox) instance** (`POST 127.0.0.1:17493/generate`) — fully on-machine, no cloud key, no usage cost.

## Changes

- **`extractNarrationText`** — pure markdown→spoken-text (title first; code blocks omitted; TOC/images/URLs stripped; inline code kept).
- **`narrationManifest`** — pure (re)generate/skip decision via content-hash manifest; prunes deleted posts; `--force`. Manifest records each post's audio extension.
- **`synthesize`** — swappable `TtsAdapter`; current impl is a local Voicebox HTTP client with defensive response handling (binary audio or JSON base64/path) and content-type→extension inference.
- **`scripts/generate-narration.ts`** (`npm run tts`) — reads the `blog` collection (respects frontmatter `slug`, skips drafts), threads post language, writes `public/audio/<slug>.<ext>` + `manifest.json`. `--dry-run` lists work; dry-runs automatically until `VOICEBOX_PROFILE_ID` is set.
- **`ListenButton`** island (takes the audio `src`), wired into `PostDetails` on the `<Datetime>` line; rendered only when the manifest has the post.
- **Vitest** + 18 tests for the two deep modules; ADR 0002 + CONTEXT.md terms.

## Verification

`npm test` → 18 passed · `astro check` → 0 errors · `npm run tts -- --dry-run` → lists all 35 posts · `npm run build` → 115 pages · eslint clean.

## How to generate audio

1. Run Voicebox locally; create/clone the voice profile.
2. Export `VOICEBOX_PROFILE_ID` (find it via `curl http://127.0.0.1:17493/profiles`); optionally `VOICEBOX_URL`.
3. `npm run tts` — writes the MP3s and manifest; commit `public/audio/`.

Until then no **Ouvir control** appears (the manifest is empty).

## Not in this PR (by design)

- Creating the cloned voice itself; on-demand/serverless synthesis; external audio storage; narration for other collections; a full mini-player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added listen button on blog posts enabling audio narration playback with play/pause controls

* **Documentation**
  * Expanded architecture documentation with narration system design, workflows, and configuration details

* **Tests**
  * Introduced comprehensive test coverage for narration text extraction, hash computation, and audio planning logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->